### PR TITLE
Update the clear job id's constant

### DIFF
--- a/ironic/drivers/modules/drac/management.py
+++ b/ironic/drivers/modules/drac/management.py
@@ -87,7 +87,7 @@ _DRAC_BOOT_MODES = ['Bios', 'Uefi']
 _NON_PERSISTENT_BOOT_MODE = 'OneTime'
 
 # Clear job id's constant
-_CLEAR_JOB_IDS = 'JID_CLEARALL_FORCE'
+_CLEAR_JOB_IDS = 'JID_CLEARALL'
 
 # Clean steps constant
 _CLEAR_JOBS_CLEAN_STEPS = ['clear_job_queue', 'known_good_state']

--- a/ironic/tests/unit/drivers/modules/drac/test_management.py
+++ b/ironic/tests/unit/drivers/modules/drac/test_management.py
@@ -813,7 +813,7 @@ class DracManagementTestCase(test_utils.BaseDracTest):
             mock_client.reset_idrac.assert_called_once_with(
                 force=True, wait=True)
             mock_client.delete_jobs.assert_called_once_with(
-                job_ids=['JID_CLEARALL_FORCE'])
+                job_ids=['JID_CLEARALL'])
 
             self.assertIsNone(return_value)
 
@@ -825,7 +825,7 @@ class DracManagementTestCase(test_utils.BaseDracTest):
                                   shared=False) as task:
             return_value = task.driver.management.clear_job_queue(task)
             mock_client.delete_jobs.assert_called_once_with(
-                job_ids=['JID_CLEARALL_FORCE'])
+                job_ids=['JID_CLEARALL'])
 
             self.assertIsNone(return_value)
 

--- a/releasenotes/notes/update-clear-job-id-constant-fix-c69cf96c55364bb3.yaml
+++ b/releasenotes/notes/update-clear-job-id-constant-fix-c69cf96c55364bb3.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    Fixes an issue of powering off created server with idrac-wsman as 
+    management interface while execution of clear job queue cleanning step. 
+    Earlier clean step was geting failed while powering off the server during
+    clean step execution.


### PR DESCRIPTION
Fixes an issue of powering off created server with idrac-wsman as
management interface while execution of clear job queue cleanning step.

Story: 2008988
Task: 42641